### PR TITLE
feat(nominatim): multi region deployments

### DIFF
--- a/charts/nominatim/Chart.yaml
+++ b/charts/nominatim/Chart.yaml
@@ -21,7 +21,7 @@ version: 3.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "4.1"
+appVersion: "4.2"
 
 dependencies:
   - name: common

--- a/charts/nominatim/README.md
+++ b/charts/nominatim/README.md
@@ -122,13 +122,30 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                                       | Description                                                   | Value                |
 | ------------------------------------------ | ------------------------------------------------------------- | -------------------- |
 | `nominatimInitialize.enabled`              | enable/disable init job                                       | `false `             |
-| `nominatimInitialize.pbfUrl`               | URL of the pbf file to import                                 | `https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf` |
+| `nominatimInitialize.pbfUrl`               | URL of the pbf file to import (ignored if `multiRegion.enabled = true`) | `https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf` |
 | `nominatimInitialize.importWikipedia`      | If additional Wikipedia/Wikidata rankings should be imported  | `false`               |
 | `nominatimInitialize.importGB_Postcode`    | If external GB postcodes should be imported                   | `false`               |
 | `nominatimInitialize.importUS_Postcode`    | If external US postcodes should be imported                   | `false`               |
 | `nominatimInitialize.importStyle`          | Nominatim import style                                        | `full`                |
 | `nominatimInitialize.customStyleUrl`       | Custom import style file URL                                  | `nil`                 |
 | `nominatimInitialize.threads`              | The number of thread used by the import                       | `16`                  |
+
+### Nominatim Multi Region Configuration parameters
+
+| Name                                       | Description                                                   | Value                |
+| ------------------------------------------ | ------------------------------------------------------------- | -------------------- |
+| `multiRegion.enabled`                      | enable/disable multi region (init with multiple pbf files)    | `false `             |
+| `multiRegion.baseUrl`                      | Base URL for the replication server url                       | `https://download.geofabrik.de` |
+| `multiRegion.fileSuffix`                   | Suffix for the PFB file url                                   | `-latest.osm.pbf`    |
+| `multiRegion.updateSuffix`                 | Suffix for the PBF update directory url                       | `-updates`           |
+| `multiRegion.updateSchedule`               | Cron schedule of how often the upstream publishes diffs       | `30 21 * * *`        |
+| `multiRegion.regions`                      | List of regions to import                                     | `[europe/germany/sachsen]` |
+| `multiRegion.updateThreads`                | The number of thread used for indexing after an update        | `16`                 |
+| `multiRegion.pvc`                          | PVC used to keep state files for updates (ignored if `nominatimReplications.enabled = false`) |  |
+| `multiRegion.pvc.storageClass`             | PVC storage class                                             | `nil`                |
+| `multiRegion.pvc.accessMode`               | PVC access mode                                               | `ReadWriteOnce`      |
+| `multiRegion.pvc.size`                     | PVC size                                                      | `1Gi`                |
+| `multiRegion.pvc.existingClaim`            | PVC existing claim                                            | `nil`                |
 
 ### Nominatim Replication Configuration parameters
 
@@ -183,10 +200,13 @@ The command removes all the Kubernetes components associated with the chart and 
 | `postgresql.primary.persistence.storageClass` | Persistent Volume storage class                                              | `nil`                         |
 | `postgresql.primary.persistence.accessModes`  | Persistent Volume access modes                                               | `[ReadWriteOnce]`             |
 | `postgresql.primary.persistence.size`         | Persistent Volume size                                                       | `500Gi`                       |
- | `externalDatase.host`                         | External PostgreSQL host (ignored if `postgresql.enabled = true`)            | localhost                     |
- | `externalDatase.port`                         | External PostgreSQL post (ignored if `postgresql.enabled = true`)            | 5432                          |
- | `externalDatase.user`                         | External PostgreSQL user (ignored if `postgresql.enabled = true`)            | nominatim                     |
- | `externalDatase.password`                     | External PostgreSQL password (ignored if `postgresql.enabled = true`)        | ""                            |
+| `externalDatabase.host`                       | External PostgreSQL host (ignored if `postgresql.enabled = true`)            | localhost                     |
+| `externalDatabase.port`                       | External PostgreSQL post (ignored if `postgresql.enabled = true`)            | 5432                          |
+| `externalDatabase.user`                       | External PostgreSQL user (ignored if `postgresql.enabled = true`)            | nominatim                     |
+| `externalDatabase.password`                   | External PostgreSQL password (ignored if `postgresql.enabled = true`)        | ""                            |
+| `externalDatabase.readerHost`                 | External PostgreSQL read only host (ignored if `postgresql.enabled = true`)  | ""                            |
+| `externalDatabase.readerPort`                 | External PostgreSQL read only port (ignored if `postgresql.enabled = true`)  | ""                            |
+
 ## Configuration and installation details
 
 ### Flatnode support

--- a/charts/nominatim/templates/_helpers.tpl
+++ b/charts/nominatim/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Name of the pvc used for multi-region updates
+Name of the pvc used for multiRegion updates
 */}}
 {{- define "nominatim.updatePvcName" -}}
 {{- printf "%s-update" (include "nominatim.fullname" .) -}}

--- a/charts/nominatim/templates/_helpers.tpl
+++ b/charts/nominatim/templates/_helpers.tpl
@@ -128,6 +128,10 @@ Create the database URL.
 pgsql:host={{ include "nominatim.databaseHost" . }};port={{ include "nominatim.databasePort" . }};user={{ include "nominatim.databaseUser" . }};password={{ include "nominatim.databasePassword" . }};dbname={{ include "nominatim.databaseName" . }}
 {{- end }}
 
+{{- define "nominatim.databaseSecret" -}}
+{{- printf "%s-%s" (include "nominatim.fullname" .) "postgresql" }}
+{{- end }}
+
 {{- define "nominatim.containerPort" -}}
 {{- ternary 80 8080 .Values.nominatimUi.enabled -}}
 {{- end }}

--- a/charts/nominatim/templates/_helpers.tpl
+++ b/charts/nominatim/templates/_helpers.tpl
@@ -62,6 +62,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Name of the pvc used for multi-region updates
+*/}}
+{{- define "nominatim.updatePvcName" -}}
+{{- printf "%s-update" (include "nominatim.fullname" .) -}}
+{{- end }}
+
+{{/*
 Create a default fully qualified postgresql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/nominatim/templates/_helpers.tpl
+++ b/charts/nominatim/templates/_helpers.tpl
@@ -92,6 +92,22 @@ Add environment variables to configure database values
 {{- end -}}
 {{- end -}}
 
+{{/*
+DB Host used for read only connections
+*/}}
+{{- define "nominatim.databaseReaderHost" -}}
+{{- if .Values.postgresql.enabled }}
+    {{- printf "%s" (include "nominatim.postgresql.fullname" .) -}}
+{{- else -}}
+    {{- if .Values.externalDatabase.readerHost -}}
+        {{- printf "%s" .Values.externalDatabase.readerHost -}}
+    {{- else -}}
+        {{- printf "%s" .Values.externalDatabase.host -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+
 {{- define "nominatim.databasePort" -}}
 {{- if .Values.postgresql.enabled }}
     {{- printf "%d" (.Values.postgresql.primary.service.ports.postgresql | int ) -}}
@@ -100,6 +116,17 @@ Add environment variables to configure database values
 {{- end -}}
 {{- end -}}
 
+{{- define "nominatim.databaseReaderPort" -}}
+{{- if .Values.postgresql.enabled }}
+    {{- printf "%d" (.Values.postgresql.primary.service.ports.postgresql | int ) -}}
+{{- else -}}
+    {{- if .Values.externalDatabase.readerPort -}}
+        {{- printf "%d" (.Values.externalDatabase.readerPort | int ) -}}
+    {{- else -}}
+        {{- printf "%d" (.Values.externalDatabase.port | int ) -}}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{- define "nominatim.databaseName" -}}
 {{- "nominatim" -}}
@@ -126,6 +153,13 @@ Create the database URL.
 */}}
 {{- define "nominatim.databaseUrl" -}}
 pgsql:host={{ include "nominatim.databaseHost" . }};port={{ include "nominatim.databasePort" . }};user={{ include "nominatim.databaseUser" . }};password={{ include "nominatim.databasePassword" . }};dbname={{ include "nominatim.databaseName" . }}
+{{- end }}
+
+{{/*
+Create the database readonly URL.
+*/}}
+{{- define "nominatim.databaseReaderUrl" -}}
+pgsql:host={{ include "nominatim.databaseReaderHost" . }};port={{ include "nominatim.databaseReaderPort" . }};user={{ include "nominatim.databaseUser" . }};password={{ include "nominatim.databasePassword" . }};dbname={{ include "nominatim.databaseName" . }}
 {{- end }}
 
 {{- define "nominatim.databaseSecret" -}}

--- a/charts/nominatim/templates/deployment.yaml
+++ b/charts/nominatim/templates/deployment.yaml
@@ -57,6 +57,9 @@ spec:
             - /bin/bash
             - -ec
             - |
+                echo "replacing UPDATE statements with SET statements"
+                curl 'https://raw.githubusercontent.com/osm-search/Nominatim/e9e14834bc3ae398e1ac161281591bd99c9b458f/lib-php/DB.php' -o /usr/local/lib/nominatim/lib-php/DB.php
+                echo "replaced UPDATE statements with SET statements"
                 nominatim refresh --website
                 a2enmod rewrite
                 /usr/sbin/apache2ctl -D FOREGROUND

--- a/charts/nominatim/templates/deployment.yaml
+++ b/charts/nominatim/templates/deployment.yaml
@@ -47,7 +47,10 @@ spec:
             {{- include "common.tplvalues.render" (dict "value" .Values.nominatim.extraEnv "context" $) | nindent 12 }}
             {{- end }}
             - name: NOMINATIM_DATABASE_DSN
-              value: {{ include "nominatim.databaseUrl" . }}
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ include "nominatim.databaseSecret" . | quote }}
+                  key: databaseUrl
             - name: NOMINATIM_REPLICATION_URL
               value: {{ .Values.nominatimReplications.replicationUrl }}
           command:

--- a/charts/nominatim/templates/deployment.yaml
+++ b/charts/nominatim/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               valueFrom:
                 secretKeyRef: 
                   name: {{ include "nominatim.databaseSecret" . | quote }}
-                  key: databaseUrl
+                  key: databaseReaderUrl
             - name: NOMINATIM_REPLICATION_URL
               value: {{ .Values.nominatimReplications.replicationUrl }}
           command:

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -76,7 +76,8 @@ spec:
 
 {{- if .Values.multiRegion.enabled }}
 {{- range $index, $region := .Values.multiRegion.regions }}
-        - name: download-pbf-{{ $region }}
+{{ $name := splitList "/" $region | last }}
+        - name: download-pbf-{{ $name }}
           image: curlimages/curl
           workingDir: /nominatim
           volumeMounts:

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -38,6 +38,8 @@ spec:
               name: data
           command:
             - curl
+            - -A
+            - {{ .Values.nominatimInitialize.userAgent }}
             - https://nominatim.org/data/wikimedia-importance.sql.gz
             - -L
             - -o
@@ -53,6 +55,8 @@ spec:
               name: data
           command:
             - curl
+            - -A
+            - {{ .Values.nominatimInitialize.userAgent }}
             - https://www.nominatim.org/data/gb_postcodes.csv.gz
             - -L
             - -o
@@ -68,6 +72,8 @@ spec:
               name: data
           command:
             - curl
+            - -A
+            - {{ .Values.nominatimInitialize.userAgent }}
             - https://www.nominatim.org/data/us_postcodes.csv.gz
             - -L
             - -o

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -74,8 +74,8 @@ spec:
             - us_postcodes.csv.gz
 {{- end }}
 
-{{- if .Values.multi-region.enabled }}
-{{- range $index, $region := .Values.multi-region.regions }}
+{{- if .Values.multiRegion.enabled }}
+{{- range $index, $region := .Values.multiRegion.regions }}
         - name: download-pbf-{{ $region }}
           image: curlimages/curl
           workingDir: /nominatim
@@ -85,7 +85,7 @@ spec:
           command:
             - curl
             - -L
-            - {{ printf "%s/%s%s" .Values.multi-region.baseUrl $region .Values.multi-region.fileSuffix }}
+            - {{ printf "%s/%s%s" $.Values.multiRegion.baseUrl $region $.Values.multiRegion.fileSuffix }}
             - --create-dirs
             - -o
             - {{ $region }}.osm.pbf
@@ -107,7 +107,7 @@ spec:
 {{- end }}
 
       containers:
-      {{- if and .Values.multi-region.enabled .Values.nominatimReplications.enabled }}
+      {{- if and .Values.multiRegion.enabled .Values.nominatimReplications.enabled }}
         - name: setup-updates
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           workingDir: /nominatim
@@ -155,8 +155,8 @@ spec:
             - name: NOMINATIM_DATABASE_WEBUSER
               value: {{ include "nominatim.databaseUser" . }}
 {{- $osm_files := "" }}
-{{- if .Values.nominatimInitialize.multi-region.enabled }}
-{{- range $index, $region := .Values.multi-region.regions }}
+{{- if .Values.multiRegion.enabled }}
+{{- range $index, $region := .Values.multiRegion.regions }}
 {{- $osm_files = printf "%s --osm-file %s.osm.pbf" $osm_files $region }}
 {{- end }}
 {{- else }}
@@ -198,10 +198,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if .Values.multi-region.enabled }}
+        {{- if .Values.multiRegion.enabled }}
         - name: updates
           persistentVolumeClaim:
-            claimName: {{ .Values.multi-region.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}
+            claimName: {{ .Values.multiRegion.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}
         {{- end }}
         {{- if  .Values.flatnode.enabled }}
         - name: flatnode

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -144,7 +144,10 @@ spec:
               value: {{ .Values.nominatimInitialize.importStyle }}
             {{- end }}
             - name: NOMINATIM_DATABASE_DSN
-              value: {{ include "nominatim.databaseUrl" . }}
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ include "nominatim.databaseSecret" . | quote }}
+                  key: databaseUrl
             {{- if .Values.flatnode.enabled }}
             - name: NOMINATIM_FLATNODE_FILE
               value: /nominatim/flatnode/flatnode.file

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -74,6 +74,23 @@ spec:
             - us_postcodes.csv.gz
 {{- end }}
 
+{{- if .Values.multi-region.enabled }}
+{{- range $index, $region := .Values.multi-region.regions }}
+        - name: download-pbf-{{ $region }}
+          image: curlimages/curl
+          workingDir: /nominatim
+          volumeMounts:
+            - mountPath: /nominatim
+              name: data
+          command:
+            - curl
+            - -L
+            - {{ printf "%s/%s%s" .Values.multi-region.baseUrl $region .Values.multi-region.fileSuffix }}
+            - --create-dirs
+            - -o
+            - {{ $region }}.osm.pbf
+{{- end }}
+{{- else }}
         - name: download-pbf
           image: curlimages/curl
           workingDir: /nominatim
@@ -87,8 +104,29 @@ spec:
             - --create-dirs
             - -o
             - data.osm.pbf
+{{- end }}
 
       containers:
+      {{- if and .Values.multi-region.enabled .Values.nominatimReplications.enabled }}
+        - name: setup-updates
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          workingDir: /nominatim
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: REGIONS
+              value: {{ join " " .Values.multi-region.regions }}
+          command: |
+            for REGION in $REGIONS;
+            do
+              mkdir -p "updates/$REGION" && touch "updates/$REGION/sequence.state"
+              pyosmium-get-changes -v -O "$REGION.osm.pbf" -f updates/$REGION/sequence.state
+            done
+          volumeMounts:
+            - mountPath: /nominatim
+              name: data
+            - mountPath: /nominatim/updates
+              name: updates
+      {{- end}}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           workingDir: /nominatim
@@ -113,11 +151,19 @@ spec:
               value: {{ .Values.nominatimInitialize.threads | quote }}
             - name: NOMINATIM_DATABASE_WEBUSER
               value: {{ include "nominatim.databaseUser" . }}
+{{- $osm_files := "" }}
+{{- if .Values.nominatimInitialize.multi-region.enabled }}
+{{- range $index, $region := .Values.multi-region.regions }}
+{{- $osm_files = printf "%s --osm-file %s.osm.pbf" $osm_files $region }}
+{{- end }}
+{{- else }}
+{{- $osm_files = "--osm-file data.osm.pbf" }}
+{{- end }}
           command:
             - /bin/bash
             - -ec
             - |
-              nominatim import --osm-file data.osm.pbf --threads $THREADS
+              nominatim import {{ $osm_files }} --threads $THREADS
               nominatim index --threads $THREADS
               nominatim admin --check-database
 
@@ -149,6 +195,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        {{- if .Values.multi-region.enabled }}
+        - name: updates
+          persistentVolumeClaim:
+            claimName: {{ .Values.multi-region.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}
+        {{- end }}
         {{- if  .Values.flatnode.enabled }}
         - name: flatnode
           persistentVolumeClaim:

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -208,7 +208,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if .Values.multiRegion.enabled }}
+        {{- if and .Values.multiRegion.enabled .Values.nominatimReplications.enabled }}
         - name: updates
           persistentVolumeClaim:
             claimName: {{ .Values.multiRegion.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}

--- a/charts/nominatim/templates/initJob.yaml
+++ b/charts/nominatim/templates/initJob.yaml
@@ -114,13 +114,16 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: REGIONS
-              value: {{ join " " .Values.multi-region.regions }}
-          command: |
-            for REGION in $REGIONS;
-            do
-              mkdir -p "updates/$REGION" && touch "updates/$REGION/sequence.state"
-              pyosmium-get-changes -v -O "$REGION.osm.pbf" -f updates/$REGION/sequence.state
-            done
+              value: {{ join " " .Values.multiRegion.regions }}
+          command: 
+            - /bin/bash
+            - -ec
+            - |
+              for REGION in $REGIONS;
+              do
+                mkdir -p "updates/$REGION" && touch "updates/$REGION/sequence.state"
+                pyosmium-get-changes -v -O "$REGION.osm.pbf" -f updates/$REGION/sequence.state
+              done
           volumeMounts:
             - mountPath: /nominatim
               name: data

--- a/charts/nominatim/templates/pvc.yaml
+++ b/charts/nominatim/templates/pvc.yaml
@@ -27,7 +27,7 @@ metadata:
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
   accessModes:
-    {{- range .Values.flatnode.accessModes }}
+    {{- range .Values.multiRegion.pvc.accessModes }}
     - {{ . | quote }}
       {{- end }}
   resources:

--- a/charts/nominatim/templates/pvc.yaml
+++ b/charts/nominatim/templates/pvc.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.flatnode.enabled (not .Values.flatnode.existingClaim) }}
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,4 +15,24 @@ spec:
     requests:
       storage: {{ .Values.flatnode.size | quote }}
   {{- include "common.storage.class" (dict "persistence" .Values.flatnode "global" .Values.global) | nindent 2 }}
+...
+{{- end}}
+{{- if and .Values.nominatimReplications.enabled (and .Values.multi-region.enabled (not .Values.multi-region.existingClaim)) }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "nominatim.updatePvcName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.flatnode.accessModes }}
+    - {{ . | quote }}
+      {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.multi-region.pvc.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.multi-region.pvc "global" .Values.global) | nindent 2 }}
+...
 {{- end}}

--- a/charts/nominatim/templates/pvc.yaml
+++ b/charts/nominatim/templates/pvc.yaml
@@ -17,7 +17,7 @@ spec:
   {{- include "common.storage.class" (dict "persistence" .Values.flatnode "global" .Values.global) | nindent 2 }}
 ...
 {{- end}}
-{{- if and .Values.nominatimReplications.enabled (and .Values.multi-region.enabled (not .Values.multi-region.existingClaim)) }}
+{{- if and .Values.nominatimReplications.enabled (and .Values.multiRegion.enabled (not .Values.multiRegion.existingClaim)) }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -32,7 +32,7 @@ spec:
       {{- end }}
   resources:
     requests:
-      storage: {{ .Values.multi-region.pvc.size | quote }}
-  {{- include "common.storage.class" (dict "persistence" .Values.multi-region.pvc "global" .Values.global) | nindent 2 }}
+      storage: {{ .Values.multiRegion.pvc.size | quote }}
+  {{- include "common.storage.class" (dict "persistence" .Values.multiRegion.pvc "global" .Values.global) | nindent 2 }}
 ...
 {{- end}}

--- a/charts/nominatim/templates/secrets.yaml
+++ b/charts/nominatim/templates/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "nominatim.databaseSecret" . | quote }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+data:
+  databaseUrl: {{ include "nominatim.databaseUrl" . | b64enc }}

--- a/charts/nominatim/templates/secrets.yaml
+++ b/charts/nominatim/templates/secrets.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
 data:
   databaseUrl: {{ include "nominatim.databaseUrl" . | b64enc }}
+  databaseReaderUrl: {{ include "nominatim.databaseReaderUrl" . | b64enc }}

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -1,4 +1,87 @@
 {{- if and .Values.nominatimReplications.enabled (not .Values.nominatimInitialize.enabled) }}
+{{- if .Values.multi-region.enabled }}
+apiVersion: v1
+kind: CronJob
+metadata:
+  name: {{ include "nominatim.fullname" . }}-updates
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.multi-region.updateSchedule }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/name: {{ include "nominatim.name" . }}-updates
+        spec:
+          containers:
+            - name: {{ include "nominatim.fullname" . }}-updates
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              workingDir: /nominatim
+              env:
+                - name: REGIONS
+                  value: {{ join " " .Values.multi-region.regions }}
+                - name: BASE_URL
+                  value: {{ .Values.multi-region.baseUrl }}
+                - name: SUFFIX
+                  value: {{ .Values.multi-region.updateSuffix }}
+                - name: NOMINATIM_DATABASE_DSN
+                  value: {{ include "nominatim.databaseUrl" . }}
+                - name: NOMINATIM_IMPORT_STYLE
+                  value: {{ .Values.nominatimInitialize.importStyle }}
+                - name: THREADS
+                  value: {{ .Values.multi-region.updateThreads }}
+                {{- if .Values.flatnode.enabled }}
+                - name: NOMINATIM_FLATNODE_FILE
+                  value: /nominatim/flatnode/flatnode.file
+                {{- end }}
+                {{- if .Values.nominatimReplications.extraEnv }}
+                {{- include "common.tplvalues.render" (dict "value" .Values.nominatim.extraEnv "context" $) | nindent 12 }}
+              {{- end }}
+              command: |
+                for REGION in $REGIONS;
+                do
+                  echo "Updating $REGION"
+                  echo "Getting changes"
+                  pyosmiuim-get-changes -v -o "$REGION.osc.gz" -f "updates/$REGION/sequence.state" --server "$BASE_URL/$REGION$SUFFIX"
+                  echo "Importing changes"
+                  nominatim add-data --diff "$REGION.osc.gz"
+                  echo "Removing changes file"
+                  rm "$REGION.osc.gz"
+                done
+
+                echo "Updating search index"
+                nominatim index -j $THREADS
+              
+              volumeMounts:
+                - mountPath: /nominatim/updates
+                  name: updates
+                - mountPath: /nominatim
+                  name: data
+                - mountPath: /dev/shm
+                  name: dshm
+                {{- if .Values.flatnode.enabled }}
+                - mountPath: /nominatim/flatnode
+                  name: flatnode
+                {{- end }}
+          restartPolicy: Never
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 8 }}
+          {{- end }}
+          volumes:
+            - name: updates
+              persistentVolumeClaim:
+                claimName: {{ .Values.multi-region.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}
+            - name: data
+              emptyDir: {}
+            - name: dshm
+              emptyDir:
+                medium: Memory
+{{- else }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -58,4 +141,5 @@ spec:
       - name: dshm
         emptyDir:
           medium: Memory
+{{- end }}
 {{- end }}

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -41,17 +41,20 @@ spec:
                 {{- if .Values.nominatimReplications.extraEnv }}
                 {{- include "common.tplvalues.render" (dict "value" .Values.nominatim.extraEnv "context" $) | nindent 12 }}
               {{- end }}
-              command: |
-                for REGION in $REGIONS;
-                do
-                  echo "Updating $REGION"
-                  echo "Getting changes"
-                  pyosmiuim-get-changes -v -o "$REGION.osc.gz" -f "updates/$REGION/sequence.state" --server "$BASE_URL/$REGION$SUFFIX"
-                  echo "Importing changes"
-                  nominatim add-data --diff "$REGION.osc.gz"
-                  echo "Removing changes file"
-                  rm "$REGION.osc.gz"
-                done
+              command:
+                - /bin/bash
+                - -ec
+                - |
+                  for REGION in $REGIONS;
+                  do
+                    echo "Updating $REGION"
+                    echo "Getting changes"
+                    pyosmiuim-get-changes -v -o "$REGION.osc.gz" -f "updates/$REGION/sequence.state" --server "$BASE_URL/$REGION$SUFFIX"
+                    echo "Importing changes"
+                    nominatim add-data --diff "$REGION.osc.gz"
+                    echo "Removing changes file"
+                    rm "$REGION.osc.gz"
+                  done
 
                 echo "Updating search index"
                 nominatim index -j $THREADS

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.nominatimReplications.enabled (not .Values.nominatimInitialize.enabled) }}
-{{- if .Values.multi-region.enabled }}
+{{- if .Values.multiRegion.enabled }}
 apiVersion: v1
 kind: CronJob
 metadata:
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
 spec:
-  schedule: {{ .Values.multi-region.updateSchedule }}
+  schedule: {{ .Values.multiRegion.updateSchedule }}
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -23,17 +23,17 @@ spec:
               workingDir: /nominatim
               env:
                 - name: REGIONS
-                  value: {{ join " " .Values.multi-region.regions }}
+                  value: {{ join " " .Values.multiRegion.regions }}
                 - name: BASE_URL
-                  value: {{ .Values.multi-region.baseUrl }}
+                  value: {{ .Values.multiRegion.baseUrl }}
                 - name: SUFFIX
-                  value: {{ .Values.multi-region.updateSuffix }}
+                  value: {{ .Values.multiRegion.updateSuffix }}
                 - name: NOMINATIM_DATABASE_DSN
                   value: {{ include "nominatim.databaseUrl" . }}
                 - name: NOMINATIM_IMPORT_STYLE
                   value: {{ .Values.nominatimInitialize.importStyle }}
                 - name: THREADS
-                  value: {{ .Values.multi-region.updateThreads }}
+                  value: {{ .Values.multiRegion.updateThreads }}
                 {{- if .Values.flatnode.enabled }}
                 - name: NOMINATIM_FLATNODE_FILE
                   value: /nominatim/flatnode/flatnode.file
@@ -56,8 +56,8 @@ spec:
                     rm "$REGION.osc.gz"
                   done
 
-                echo "Updating search index"
-                nominatim index -j $THREADS
+                  echo "Updating search index"
+                  nominatim index -j $THREADS
               
               volumeMounts:
                 - mountPath: /nominatim/updates
@@ -78,7 +78,7 @@ spec:
           volumes:
             - name: updates
               persistentVolumeClaim:
-                claimName: {{ .Values.multi-region.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}
+                claimName: {{ .Values.multiRegion.pvc.existingClaim | default (include "nominatim.updatePvcName" .) }}
             - name: data
               emptyDir: {}
             - name: dshm

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -30,7 +30,10 @@ spec:
                 - name: SUFFIX
                   value: {{ .Values.multiRegion.updateSuffix }}
                 - name: NOMINATIM_DATABASE_DSN
-                  value: {{ include "nominatim.databaseUrl" . }}
+                  valueFrom:
+                    secretKeyRef: 
+                      name: {{ include "nominatim.databaseSecret" . | quote }}
+                      key: databaseUrl
                 - name: NOMINATIM_IMPORT_STYLE
                   value: {{ .Values.nominatimInitialize.importStyle }}
                 - name: THREADS
@@ -110,7 +113,10 @@ spec:
           workingDir: /nominatim
           env:
             - name: NOMINATIM_DATABASE_DSN
-              value: {{ include "nominatim.databaseUrl" . }}
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ include "nominatim.databaseSecret" . | quote }}
+                  key: databaseUrl
             - name: NOMINATIM_REPLICATION_URL
               value: {{ .Values.nominatimReplications.replicationUrl }}
             - name: NOMINATIM_IMPORT_STYLE

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -49,8 +49,9 @@ spec:
                   for REGION in $REGIONS;
                   do
                     echo "Updating $REGION"
+                    mkdir -p "$REGION"
                     echo "Getting changes"
-                    pyosmiuim-get-changes -v -o "$REGION.osc.gz" -f "updates/$REGION/sequence.state" --server "$BASE_URL/$REGION$SUFFIX"
+                    pyosmium-get-changes -v -o "$REGION.osc.gz" -f "updates/$REGION/sequence.state" --server "$BASE_URL/$REGION$SUFFIX"
                     echo "Importing changes"
                     nominatim add-data --diff "$REGION.osc.gz"
                     echo "Removing changes file"
@@ -70,11 +71,11 @@ spec:
                 {{- if .Values.flatnode.enabled }}
                 - mountPath: /nominatim/flatnode
                   name: flatnode
+                  subPath: flatnode
                 {{- end }}
-          restartPolicy: Never
           {{- with .Values.nodeSelector }}
           nodeSelector:
-            {{- toYaml . | nindent 8 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           restartPolicy: Never
           volumes:

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -23,7 +23,7 @@ spec:
               workingDir: /nominatim
               env:
                 - name: REGIONS
-                  value: {{ join " " .Values.multiRegion.regions }}
+                  value: {{ join " " .Values.multiRegion.regions | quote }}
                 - name: BASE_URL
                   value: {{ .Values.multiRegion.baseUrl }}
                 - name: SUFFIX
@@ -33,7 +33,7 @@ spec:
                 - name: NOMINATIM_IMPORT_STYLE
                   value: {{ .Values.nominatimInitialize.importStyle }}
                 - name: THREADS
-                  value: {{ .Values.multiRegion.updateThreads }}
+                  value: {{ .Values.multiRegion.updateThreads | quote }}
                 {{- if .Values.flatnode.enabled }}
                 - name: NOMINATIM_FLATNODE_FILE
                   value: /nominatim/flatnode/flatnode.file

--- a/charts/nominatim/templates/updateJob.yaml
+++ b/charts/nominatim/templates/updateJob.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.nominatimReplications.enabled (not .Values.nominatimInitialize.enabled) }}
 {{- if .Values.multiRegion.enabled }}
-apiVersion: v1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ include "nominatim.fullname" . }}-updates
@@ -11,6 +11,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         metadata:
           labels:
@@ -58,7 +59,7 @@ spec:
 
                   echo "Updating search index"
                   nominatim index -j $THREADS
-              
+
               volumeMounts:
                 - mountPath: /nominatim/updates
                   name: updates
@@ -75,6 +76,7 @@ spec:
           nodeSelector:
             {{- toYaml . | nindent 8 }}
           {{- end }}
+          restartPolicy: Never
           volumes:
             - name: updates
               persistentVolumeClaim:

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -304,6 +304,12 @@ externalDatabase:
   ## @param externalDatabase.host External Database server host
   ##
   host: localhost
+  ## @param externalDatabase.readerHost External Database read only endpoint
+  ##
+  readerHost: ""
+  ## @param externalDatabase.readerPort External Database read only server port
+  ##
+  # readerPort: 5432
   ## @param externalDatabase.port External Database server port
   ##
   port: 5432

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -41,27 +41,27 @@ commonAnnotations: {}
 ##
 commonLabels: {}
 
-multi-region:
-  ## @param multi-region.enabled Enable multi-region settings
+multiRegion:
+  ## @param multiRegion.enabled Enable multiRegion settings
   ## PVC for keeping state files for updates
   ## Init with multiple pbf files
   ##
   enabled: false
-  ## @param multi-region.baseUrl Base URL for the replication server url
+  ## @param multiRegion.baseUrl Base URL for the replication server url
   ##
   baseUrl: https://download.geofabrik.de
-  ## @param multi-region.fileSuffix Suffix for the PBF file url
+  ## @param multiRegion.fileSuffix Suffix for the PBF file url
   ##
   fileSuffix: -latest.osm.pbf
-  ## @param multi-region.updateSuffix Suffix for the PBF update directory url
+  ## @param multiRegion.updateSuffix Suffix for the PBF update directory url
   ##
   updateSuffix: -updates
-  ## @param multi-region.regions List of regions to download
+  ## @param multiRegion.regions List of regions to download
   ##
   regions:
     - europe/germany/sachsen
     - europe/monaco
-  ## @param multi-region.threads Number of threads to use for indexing after an update
+  ## @param multiRegion.threads Number of threads to use for indexing after an update
   ##
   updateThreads: 16
   pvc:
@@ -71,17 +71,17 @@ multi-region:
     ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
     ##
     storageClass:
-    ## @param multi-region.pvc.accessModes [array] Persistent Volume access modes
+    ## @param multiRegion.pvc.accessModes [array] Persistent Volume access modes
     ##
     accessModes:
       - ReadWriteOnce
-    ## @param multi-region.pvc.size Persistent Volume size
+    ## @param multiRegion.pvc.size Persistent Volume size
     ##
     size: 1Gi
-    ## @param multi-region.pvc.existingClaim The name of an existing PVC to use for persistence
+    ## @param multiRegion.pvc.existingClaim The name of an existing PVC to use for persistence
     ##
     existingClaim:
-  ## @param multi-region.updateSchedule Cron schedule of how often upstream publishes diffs
+  ## @param multiRegion.updateSchedule Cron schedule of how often upstream publishes diffs
   ## For example, geofabrik publishes diffs every day around 21:00 CET so the schedule should be set to ~"15 21 */1 * *"
   ##
   updateSchedule: "30 21 */1 * *"

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -93,6 +93,7 @@ nominatimInitialize:
   importGB_Postcode: false
   importUS_Postcode: false
   importStyle: full
+  userAgent: gyroskan/helm-charts/nominatim
   # customStyleUrl: https://raw.githubusercontent.com/david-mart/Nominatim/master/settings/import-street.style
   threads: 16
   freeze: false

--- a/charts/nominatim/values.yaml
+++ b/charts/nominatim/values.yaml
@@ -41,6 +41,51 @@ commonAnnotations: {}
 ##
 commonLabels: {}
 
+multi-region:
+  ## @param multi-region.enabled Enable multi-region settings
+  ## PVC for keeping state files for updates
+  ## Init with multiple pbf files
+  ##
+  enabled: false
+  ## @param multi-region.baseUrl Base URL for the replication server url
+  ##
+  baseUrl: https://download.geofabrik.de
+  ## @param multi-region.fileSuffix Suffix for the PBF file url
+  ##
+  fileSuffix: -latest.osm.pbf
+  ## @param multi-region.updateSuffix Suffix for the PBF update directory url
+  ##
+  updateSuffix: -updates
+  ## @param multi-region.regions List of regions to download
+  ##
+  regions:
+    - europe/germany/sachsen
+    - europe/monaco
+  ## @param multi-region.threads Number of threads to use for indexing after an update
+  ##
+  updateThreads: 16
+  pvc:
+    ## @param multi-reginon.pvc.storageClass Persistent Volume storage class
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+    ##
+    storageClass:
+    ## @param multi-region.pvc.accessModes [array] Persistent Volume access modes
+    ##
+    accessModes:
+      - ReadWriteOnce
+    ## @param multi-region.pvc.size Persistent Volume size
+    ##
+    size: 1Gi
+    ## @param multi-region.pvc.existingClaim The name of an existing PVC to use for persistence
+    ##
+    existingClaim:
+  ## @param multi-region.updateSchedule Cron schedule of how often upstream publishes diffs
+  ## For example, geofabrik publishes diffs every day around 21:00 CET so the schedule should be set to ~"15 21 */1 * *"
+  ##
+  updateSchedule: "30 21 */1 * *"
+
 nominatimInitialize:
   enabled: false
   pbfUrl: https://download.geofabrik.de/europe/germany/sachsen-latest.osm.pbf
@@ -79,7 +124,8 @@ podAnnotations: {}
 podSecurityContext:
   fsGroup: 101
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -105,9 +151,10 @@ service:
   ## e.g:
   ## clusterIP: None
   ##
-  clusterIP: ""
+  clusterIP:
+    ""
 
-   ## @param service.loadBalancerIP Nominatim loadBalancerIP if service type is `LoadBalancer`
+    ## @param service.loadBalancerIP Nominatim loadBalancerIP if service type is `LoadBalancer`
   ## Set the LoadBalancer service type to internal only
   ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
   ##
@@ -182,9 +229,10 @@ ingress:
   ##       ...
   ##       -----END CERTIFICATE-----
   ##
-  secrets: [ ]
+  secrets: []
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -241,16 +289,15 @@ postgresql:
       size: 500Gi
 
     extendedConfiguration: |
-        shared_buffers = 2GB
-        maintenance_work_mem = 10GB
-        autovacuum_work_mem = 2GB
-        work_mem = 50MB
-        effective_cache_size = 24GB
-        synchronous_commit = off
-        max_wal_size = 1GB
-        checkpoint_timeout = 10min
-        checkpoint_completion_target = 0.9
-
+      shared_buffers = 2GB
+      maintenance_work_mem = 10GB
+      autovacuum_work_mem = 2GB
+      work_mem = 50MB
+      effective_cache_size = 24GB
+      synchronous_commit = off
+      max_wal_size = 1GB
+      checkpoint_timeout = 10min
+      checkpoint_completion_target = 0.9
 
 externalDatabase:
   ## @param externalDatabase.host External Database server host


### PR DESCRIPTION
Allow deployements using multiple pbfs files and still having replication available.

- add a cronjob for the updates when `multiRegion.enabled = true`
- use PVC for state files for updates only if `nominatimReplications.enabled = true`
- add the possibility to provide a read only endpoint for external databases (used for the website deployements only)
- use secrets for database urls